### PR TITLE
Removing unnecessary gradient tensor loads

### DIFF
--- a/src/equitriton/sph_harm/triton_kernels.py
+++ b/src/equitriton/sph_harm/triton_kernels.py
@@ -198,9 +198,6 @@ def _triton_second_order_bwd(
     g_x += -1.0 * sqrt_15 * x * g_2_4
     g_z += sqrt_15 * z * g_2_4
     # after all the operations are done, write back to memory
-    g_x_start = g_x_ptr + offset
-    g_y_start = g_y_ptr + offset
-    g_z_start = g_z_ptr + offset
     tl.store(g_x_ptr + offset, g_x, mask=offset < vector_length)
     tl.store(g_y_ptr + offset, g_y, mask=offset < vector_length)
     tl.store(g_z_ptr + offset, g_z, mask=offset < vector_length)
@@ -426,9 +423,6 @@ def _triton_third_order_bwd(
         * (1.08012344973464 * sq_x + 0.540061724867322 * sq_x - 1.62018517460196 * sq_z)
     )
     # after all the operations are done, write back to memory
-    g_x_start = g_x_ptr + offset
-    g_y_start = g_y_ptr + offset
-    g_z_start = g_z_ptr + offset
     tl.store(g_x_ptr + offset, g_x, mask=offset < vector_length)
     tl.store(g_y_ptr + offset, g_y, mask=offset < vector_length)
     tl.store(g_z_ptr + offset, g_z, mask=offset < vector_length)
@@ -940,9 +934,6 @@ def _triton_fourth_order_bwd(
         )
     )
     # after all the operations are done, write back to memory
-    g_x_start = g_x_ptr + offset
-    g_y_start = g_y_ptr + offset
-    g_z_start = g_z_ptr + offset
     tl.store(g_x_ptr + offset, g_x, mask=offset < vector_length)
     tl.store(g_y_ptr + offset, g_y, mask=offset < vector_length)
     tl.store(g_z_ptr + offset, g_z, mask=offset < vector_length)

--- a/src/equitriton/sph_harm/triton_kernels.py
+++ b/src/equitriton/sph_harm/triton_kernels.py
@@ -657,21 +657,13 @@ def _triton_fourth_order_bwd(
     x = tl.load(x_row_start, mask=offset < vector_length)
     y = tl.load(y_row_start, mask=offset < vector_length)
     z = tl.load(z_row_start, mask=offset < vector_length)
-    # load the pre-allocated xyz gradients
-    g_x_start = g_x_ptr + offset
-    g_y_start = g_y_ptr + offset
-    g_z_start = g_z_ptr + offset
-    # NOTE: these are the gradient outputs and are assumed to be initially zeros
-    g_x = tl.load(g_x_start, mask=offset < vector_length)
-    g_y = tl.load(g_y_start, mask=offset < vector_length)
-    g_z = tl.load(g_z_start, mask=offset < vector_length)
     # this is the first order derivative, which is just root 3
     g_1_0 = tl.load(g_1_0_ptr + offset, mask=offset < vector_length)
     g_1_1 = tl.load(g_1_1_ptr + offset, mask=offset < vector_length)
     g_1_2 = tl.load(g_1_2_ptr + offset, mask=offset < vector_length)
-    g_x += sqrt_3 * g_1_0
-    g_y += sqrt_3 * g_1_1
-    g_z += sqrt_3 * g_1_2
+    g_x = sqrt_3 * g_1_0
+    g_y = sqrt_3 * g_1_1
+    g_z = sqrt_3 * g_1_2
     # now work on the second order derivatives, grouped by m
     g_2_0 = tl.load(g_2_0_ptr + offset, mask=offset < vector_length)
     g_2_1 = tl.load(g_2_1_ptr + offset, mask=offset < vector_length)
@@ -948,6 +940,9 @@ def _triton_fourth_order_bwd(
         )
     )
     # after all the operations are done, write back to memory
+    g_x_start = g_x_ptr + offset
+    g_y_start = g_y_ptr + offset
+    g_z_start = g_z_ptr + offset
     tl.store(g_x_ptr + offset, g_x, mask=offset < vector_length)
     tl.store(g_y_ptr + offset, g_y, mask=offset < vector_length)
     tl.store(g_z_ptr + offset, g_z, mask=offset < vector_length)

--- a/src/equitriton/sph_harm/triton_kernels.py
+++ b/src/equitriton/sph_harm/triton_kernels.py
@@ -168,21 +168,13 @@ def _triton_second_order_bwd(
     x = tl.load(x_row_start, mask=offset < vector_length)
     y = tl.load(y_row_start, mask=offset < vector_length)
     z = tl.load(z_row_start, mask=offset < vector_length)
-    # load the pre-allocated xyz gradients
-    g_x_start = g_x_ptr + offset
-    g_y_start = g_y_ptr + offset
-    g_z_start = g_z_ptr + offset
-    # NOTE: these are the gradient outputs and are assumed to be initially zeros
-    g_x = tl.load(g_x_start, mask=offset < vector_length)
-    g_y = tl.load(g_y_start, mask=offset < vector_length)
-    g_z = tl.load(g_z_start, mask=offset < vector_length)
     # this is the first order derivative, which is just root 3
     g_1_0 = tl.load(g_1_0_ptr + offset, mask=offset < vector_length)
     g_1_1 = tl.load(g_1_1_ptr + offset, mask=offset < vector_length)
     g_1_2 = tl.load(g_1_2_ptr + offset, mask=offset < vector_length)
-    g_x += sqrt_3 * g_1_0
-    g_y += sqrt_3 * g_1_1
-    g_z += sqrt_3 * g_1_2
+    g_x = sqrt_3 * g_1_0
+    g_y = sqrt_3 * g_1_1
+    g_z = sqrt_3 * g_1_2
     # now work on the second order derivatives, grouped by m
     g_2_0 = tl.load(g_2_0_ptr + offset, mask=offset < vector_length)
     g_2_1 = tl.load(g_2_1_ptr + offset, mask=offset < vector_length)
@@ -206,6 +198,9 @@ def _triton_second_order_bwd(
     g_x += -1.0 * sqrt_15 * x * g_2_4
     g_z += sqrt_15 * z * g_2_4
     # after all the operations are done, write back to memory
+    g_x_start = g_x_ptr + offset
+    g_y_start = g_y_ptr + offset
+    g_z_start = g_z_ptr + offset
     tl.store(g_x_ptr + offset, g_x, mask=offset < vector_length)
     tl.store(g_y_ptr + offset, g_y, mask=offset < vector_length)
     tl.store(g_z_ptr + offset, g_z, mask=offset < vector_length)
@@ -347,21 +342,14 @@ def _triton_third_order_bwd(
     x = tl.load(x_row_start, mask=offset < vector_length)
     y = tl.load(y_row_start, mask=offset < vector_length)
     z = tl.load(z_row_start, mask=offset < vector_length)
-    # load the pre-allocated xyz gradients
-    g_x_start = g_x_ptr + offset
-    g_y_start = g_y_ptr + offset
-    g_z_start = g_z_ptr + offset
-    # NOTE: these are the gradient outputs and are assumed to be initially zeros
-    g_x = tl.load(g_x_start, mask=offset < vector_length)
-    g_y = tl.load(g_y_start, mask=offset < vector_length)
-    g_z = tl.load(g_z_start, mask=offset < vector_length)
     # this is the first order derivative, which is just root 3
     g_1_0 = tl.load(g_1_0_ptr + offset, mask=offset < vector_length)
     g_1_1 = tl.load(g_1_1_ptr + offset, mask=offset < vector_length)
     g_1_2 = tl.load(g_1_2_ptr + offset, mask=offset < vector_length)
-    g_x += sqrt_3 * g_1_0
-    g_y += sqrt_3 * g_1_1
-    g_z += sqrt_3 * g_1_2
+    # initialize gradients
+    g_x = sqrt_3 * g_1_0
+    g_y = sqrt_3 * g_1_1
+    g_z = sqrt_3 * g_1_2
     # now work on the second order derivatives, grouped by m
     g_2_0 = tl.load(g_2_0_ptr + offset, mask=offset < vector_length)
     g_2_1 = tl.load(g_2_1_ptr + offset, mask=offset < vector_length)
@@ -438,6 +426,9 @@ def _triton_third_order_bwd(
         * (1.08012344973464 * sq_x + 0.540061724867322 * sq_x - 1.62018517460196 * sq_z)
     )
     # after all the operations are done, write back to memory
+    g_x_start = g_x_ptr + offset
+    g_y_start = g_y_ptr + offset
+    g_z_start = g_z_ptr + offset
     tl.store(g_x_ptr + offset, g_x, mask=offset < vector_length)
     tl.store(g_y_ptr + offset, g_y, mask=offset < vector_length)
     tl.store(g_z_ptr + offset, g_z, mask=offset < vector_length)


### PR DESCRIPTION
## Proposed changes

Based on discussions with @Pennycook, this PR provides a small but noticable performance bump to the first version of EquiTriton kernels. Comparison with the `e3nn` + `torch.compile` autotuned kernels showed that the backward pass contained unnecessary memory loads that introduced an element-wise latency.

Originally, variables for accumulating gradients were initialized by performing `tl.load`. The optimization introduced here is to remove this load dependency, allowing `g_x/y/z` to be calculated as soon as the first order gradients are streamed in. The main impact I've seen from running these kernels is removing the significant dropoff in performance at higher node counts seen in #9 from 10^5 nodes and above, making relative performance more or less constant across node counts. Tested on a 1100 GPU Max on PyTorch `2.6.0a0+git487873f`, and `triton==3.1.0`.

cc @mitkotak in case you're interested in tracking these changes

## Types of changes

What types of changes does your code introduce to the project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (if none of the other choices apply)
- [x] Performance optimization

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you are unsure about any of them, do not hesitate to ask. We are
here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/IntelLabs/EquiTriton/blob/main/CONTRIBUTING.md) agreement
- [x] Current formatting and unit tests / base functionality passes locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
